### PR TITLE
If firewall mask is 0, it has to be empty for ufw command

### DIFF
--- a/app/SSH/Services/Firewall/Ufw.php
+++ b/app/SSH/Services/Firewall/Ufw.php
@@ -30,7 +30,7 @@ class Ufw extends AbstractFirewall
                 'protocol' => $protocol,
                 'port' => $port,
                 'source' => $source,
-                'mask' => $mask || $mask == 0 ? '/'.$mask : '',
+                'mask' => $mask || $mask != 0 ? '/'.$mask : '',
             ]),
             'add-firewall-rule'
         );
@@ -44,7 +44,7 @@ class Ufw extends AbstractFirewall
                 'protocol' => $protocol,
                 'port' => $port,
                 'source' => $source,
-                'mask' => $mask || $mask == 0 ? '/'.$mask : '',
+                'mask' => $mask || $mask != 0 ? '/'.$mask : '',
             ]),
             'remove-firewall-rule'
         );


### PR DESCRIPTION
In order to add new firewall rules without mask/subnet the interface requires a number for the mask field. Default is 0. Currently 0 leads to a ufw cli command like this:

```bash
sudo ufw allow from 123.123.123.123/0 to any proto tcp port 22
```

This command is not valid as the command returns:

```bash
vito@vito-012:~$ sudo ufw allow from 123.123.123.123/0 to any proto tcp port 22
WARN: Rule changed after normalization
Skipping adding existing rule
```

The code now checks if the mask is present and NOT 0 so it only append ~ /24 to the source IP when mask is set to a valid value.

With that change you are able to add new ufw rules on Ubuntu 24.04 and remove the default 22 from any rule.